### PR TITLE
Use zero values for thresholds

### DIFF
--- a/check_haproxy
+++ b/check_haproxy
@@ -28,6 +28,7 @@ use Getopt::Long qw(:config no_ignore_case);
 use Pod::Usage;
 use IO::Socket::UNIX qw( SOCK_STREAM );
 use Data::Dumper;
+use Scalar::Util qw(looks_like_number);
 
 # Configure Program details
 our ($_program, $_version, $_author);
@@ -402,10 +403,10 @@ sub build_checks {
   if (defined $opt{'defaults'}
       and $opt{'defaults'} =~ /([ud]?),(?:((?:0?\.)?[0-9]*)(?:,((?:0?\.)?[0-9]*)(?:,((?:0?\.)?[0-9]*)%?(?:,((?:0?\.)?[0-9]*)%?)?)?)?)?/) {
     $state      =  $1       if $1;
-    $be_warn    =  $2       if $2;
-    $be_crit    =  $3       if $3;
-    $limit_warn = ($4/100)  if $4;
-    $limit_crit = ($5/100)  if $5;
+    $be_warn    =  $2       if looks_like_number($2);
+    $be_crit    =  $3       if looks_like_number($3);
+    $limit_warn = ($4/100)  if looks_like_number($4);
+    $limit_crit = ($5/100)  if looks_like_number($5);
     _debug('build_checks',
            _('setting defaults to %s,%.2f,%.2f,%.2f,%.2f',
              $state, $be_warn, $be_crit, $limit_warn, $limit_crit));
@@ -450,12 +451,12 @@ sub build_checks {
 
     if ($data{$1}{'type'} eq TYPE_BACKEND) {
       $checks{$1}{'state'}    =  $2      if $2 and ($2 eq 'u' or $2 eq 'd' or $2 eq 'x');
-      $checks{$1}{'be_warn'}  =  $3      if $3 and $3 >= 0;
-      $checks{$1}{'be_crit'}  =  $4      if $4 and $4 >= 0;
+      $checks{$1}{'be_warn'}  =  $3      if looks_like_number($3) and $3 >= 0;
+      $checks{$1}{'be_crit'}  =  $4      if looks_like_number($4) and $4 >= 0;
     }
 
-    $checks{$1}{'limit_warn'} = ($5/100) if $5 and $5 > 0 and $5 <= 100;
-    $checks{$1}{'limit_crit'} = ($6/100) if $6 and $6 > 0 and $6 <= 100;
+    $checks{$1}{'limit_warn'} = ($5/100) if looks_like_number($5) and $5 > 0 and $5 <= 100;
+    $checks{$1}{'limit_crit'} = ($6/100) if looks_like_number($6) and $6 > 0 and $6 <= 100;
 
     _debug('build_checks',
            _('setting override for %s to %s,%d,%d,%.2f,%.2f',


### PR DESCRIPTION
Zero values are replaced by hardcoded limits in `defaults` and by defaults in `overrides` arguments. 

This pull request implements #7.

Given this HAProxy configuration:

```
listen read-write
    bind *:8000
    mode http
    server instance1 127.0.0.1:8001 check 
    server instance2 127.0.0.1:8002 check

listen read-only
    bind *:9000
    mode http
    server instance1 127.0.0.1:9001 check 
    server instance2 127.0.0.1:9002 check
    server read-write 127.0.0.1:8000 backup
```

The important part is when all servers in the read-only backend are down, there is still a backup server pointing to the read-write port:

```
$ curl -I -XGET http://127.0.0.1:9000/
HTTP/1.0 200 OK
```

The situation isn't critical because it still works but it would be nice to be notified because something is wrong with the read-only backend. For defaults, we could set `u,2,1` for thresholds to warn when available servers go below count of 2 and crit below 1. It works. For the special read-only backend, we could set `u,1,0` to warn below 1 host down and "ignore" critical as it will never go strictly below 0:

```
$ ./check_haproxy -S /run/haproxy/admin.sock --defaults 'C<u,2,1,80,90>' --overrides read-only:'u,1,0'
HAPROXY CRITICAL: BACKEND read-only has fallen below 1 available server(s) (0 up, 0 down, 0 disabled) (check_haproxy 1.0.3)
```

Critical. It's because perl considers `0` as absence of value so `check_haproxy` falls back to defaults:

```
build_checks{} setting defaults to u,2.00,1.00,0.80,0.90
build_checks{} processing override read-only:u,1,0
build_checks{} setting override for read-only to u,1,1,0.80,0.90
check_backends{} found 0 up, 0 down, 0 disabled (3 total)
check_pass{} UP: 0 >= 1
```

Overrides go from `u,1,0` to `u,1,1,0.80,0.90`  and not `u,1,0,0.80,0.90`.

This pull request fixes this behaviour:

```
$ ./check_haproxy -S /run/haproxy/admin.sock --defaults 'C<u,2,1,80,90>' --overrides read-only:'u,1,0'
HAPROXY WARNING: BACKEND read-only has fallen below 1 available server(s) (0 up, 2 down, 0 disabled) (check_haproxy 1.0.3)
```