### PR TITLE
Fix icinga2 config

### DIFF
--- a/check_haproxy.icinga2.conf
+++ b/check_haproxy.icinga2.conf
@@ -32,7 +32,9 @@ object CheckCommand "haproxy" {
             description = "Disable checks for the servers in HAProxy (that they haven't reached the limits for the sessions or for queues)."
         }
         "--overrides" = {
-            value = "$haproxy_overrides$"
+            value = {{
+                return macro("$haproxy_overrides$").split(" ")
+            }}
             description = "Override the defaults for a particular frontend or backend, in the form {name}:{override}, where {override} is the same format as --defaults above."
         }
         "--socket" = {


### PR DESCRIPTION
Correct call `./check_haproxy -S /var/run/haproxy/admin.sock -O chat:u,2,1 stats:x`
Incorrect call `./check_haproxy -S /var/run/haproxy/admin.sock -O "chat:u,2,1 stats:x"`

Using icinga2 functions we can fix this. Using `macro()` and `split()` we are able to return multiple strings from a single input string.

Closes  #9